### PR TITLE
fix: mark types as Send and Sync

### DIFF
--- a/src/greet_usecase.rs
+++ b/src/greet_usecase.rs
@@ -1,3 +1,5 @@
+type ThreadSafeNameGateway = Box<dyn NameGateway + Send + Sync>;
+
 pub trait GreetUsecase {
     fn exec(&self) -> String;
 }
@@ -7,7 +9,13 @@ pub trait NameGateway {
 }
 
 pub struct GreetUsecaseImpl {
-    name_gateway: Box<dyn NameGateway>, // HERE YOU CAN CHANGE THE WRAPPER (Box, Rc, Arc, none, etc)
+    name_gateway: ThreadSafeNameGateway, // HERE YOU CAN CHANGE THE WRAPPER (Box, Rc, Arc, none, etc)
+}
+
+impl GreetUsecaseImpl {
+    pub fn new(name_gateway: ThreadSafeNameGateway) -> Self {
+        Self { name_gateway }
+    }
 }
 
 impl GreetUsecase for GreetUsecaseImpl {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,21 +5,19 @@ use greet_usecase::{GreetUsecase, GreetUsecaseImpl};
 use rocket as _rocket;
 
 struct State {
-    greet_usecase: Box<dyn GreetUsecase>,
+    greet_usecase: Box<dyn GreetUsecase + Send + Sync>,
 }
 
 #[_rocket::get("/")]
-fn index(state: &_rocket::State<State>) -> &'static str {
-    state.greet_usecase.exec().as_str()
+fn index(state: &_rocket::State<State>) -> String {
+    state.greet_usecase.exec()
 }
 
 #[_rocket::launch]
 fn rocket() -> _ {
     let name_gateway = Box::new(in_memory_name_gateway::InMememoryNameGateway {});
     let greet_usecase = Box::new(GreetUsecaseImpl::new(name_gateway));
-    let state = State {
-        greet_usecase: Box::new(GreetUsecaseImpl::new("world".to_string())),
-    };
+    let state = State { greet_usecase };
     rocket::build()
         .manage(state)
         .mount("/", _rocket::routes![index])


### PR DESCRIPTION
`Send` marks a type as being safe to send between threads. `Sync` marks a type as being safe to be shared between threads